### PR TITLE
vertex: Fix mapInNghs()

### DIFF
--- a/ligra/vertex.h
+++ b/ligra/vertex.h
@@ -327,8 +327,8 @@ template <template <typename W> class vertex, class W, class F>
 inline void mapNghs(vertex<W>* v, uintE vtx_id, std::tuple<uintE, W>* nghs,
                     uintE d, F& f, bool parallel) {
   par_for(0, d, pbbslib::kSequentialForThreshold, [&] (size_t j) {
-    uintE ngh = v->getOutNeighbor(j);
-    f(vtx_id, ngh, v->getOutWeight(j));
+    const std::tuple<uintE, W>& neighbor = nghs[j];
+    f(vtx_id, std::get<0>(neighbor), std::get<1>(neighbor));
   }, parallel);
 }
 


### PR DESCRIPTION
`mapInNghs()` calls `mapNghs()`, which was only using out-neighbors. This PR fixes `mapNghs()` to work for in-neighbors too.