### PR TITLE
utils: Fix makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,5 +233,10 @@ graph format to the adjacency graph format that GBBS accepts. Usage example:
 wget https://snap.stanford.edu/data/wiki-Vote.txt.gz
 gzip --decompress ${PWD}/wiki-Vote.txt.gz
 # Run the SNAP-to-adjacency-graph converter.
+# Run with Bazel:
 bazel run //utils:snap_converter -- -s -i ${PWD}/wiki-Vote.txt -o <output file>
+# Or run with Make:
+#   cd utils
+#   make snap_converter
+#   ./snap_converter -s -i <input file> -o <output_file>
 ```

--- a/README.md
+++ b/README.md
@@ -238,5 +238,5 @@ bazel run //utils:snap_converter -- -s -i ${PWD}/wiki-Vote.txt -o <output file>
 # Or run with Make:
 #   cd utils
 #   make snap_converter
-#   ./snap_converter -s -i <input file> -o <output_file>
+#   ./snap_converter -s -i <input file> -o <output file>
 ```

--- a/benchmarks/makefile.benchmarks
+++ b/benchmarks/makefile.benchmarks
@@ -36,7 +36,7 @@ pbbslib_strings :
 	make -C $(ROOTDIR)pbbslib/strings/
 
 % : %.cc pbbslib ligra ligra_encodings pbbslib_strings other
-	$(CC) $(INCLUDE_DIRS) $(CFLAGS) $(PFLAGS) -o $@ $< $(ALL_OBJS) -pthread $(LFLAGS)
+	$(CC) $(INCLUDE_DIRS) $(CFLAGS) $(PFLAGS) -o $@ $< -Wl,--start-group $(ALL_OBJS) -Wl,--end-group -pthread $(LFLAGS)
 #-Wl,--whole-archive -lpthread -Wl,--no-whole-archive -Wl,-S -Wl,-no-as-needed -Wl,-z,relro,-z,now -lstdc++ -fuse-ld=gold 
 
 .PHONY : clean

--- a/benchmarks/makefile.benchmarks
+++ b/benchmarks/makefile.benchmarks
@@ -36,7 +36,7 @@ pbbslib_strings :
 	make -C $(ROOTDIR)pbbslib/strings/
 
 % : %.cc pbbslib ligra ligra_encodings pbbslib_strings other
-	$(CC) $(INCLUDE_DIRS) $(CFLAGS) $(PFLAGS) -o $@ $< -Wl,--start-group $(ALL_OBJS) -Wl,--end-group -pthread $(LFLAGS)
+	$(CC) $(INCLUDE_DIRS) $(CFLAGS) $(PFLAGS) -o $@ $< $(LINKER_START_GROUP) $(ALL_OBJS) $(LINKER_END_GROUP) -pthread $(LFLAGS)
 #-Wl,--whole-archive -lpthread -Wl,--no-whole-archive -Wl,-S -Wl,-no-as-needed -Wl,-z,relro,-z,now -lstdc++ -fuse-ld=gold 
 
 .PHONY : clean

--- a/makefile.variables
+++ b/makefile.variables
@@ -1,3 +1,10 @@
+UNAME := $(shell uname)
+ifeq ($(UNAME), Linux)
+  OS := linux
+else ifeq ($(UNAME), Darwin)
+  OS := mac
+endif
+
 ifeq (, $(shell which jemalloc-config))
 JEMALLOC =
 else
@@ -41,4 +48,13 @@ PFLAGS =
 else # default is homegrown
 CC = g++
 PFLAGS = $(HGFLAGS)
+endif
+
+ifeq ($(OS), linux)
+  LINKER_START_GROUP := -Wl,--start-group
+  LINKER_END_GROUP := -Wl,--end-group
+else ifeq ($(OS), mac)
+  # macOS's linker doesn't use --start-group and --end-group
+  LINKER_START_GROUP :=
+  LINKER_END_GROUP :=
 endif

--- a/makefile.variables
+++ b/makefile.variables
@@ -54,7 +54,7 @@ ifeq ($(OS), linux)
   LINKER_START_GROUP := -Wl,--start-group
   LINKER_END_GROUP := -Wl,--end-group
 else ifeq ($(OS), mac)
-  # macOS's linker doesn't use --start-group and --end-group
+  # macOS's default linker doesn't use the --start-group and --end-group flags.
   LINKER_START_GROUP :=
   LINKER_END_GROUP :=
 endif

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,3 +1,5 @@
+compressor
 converter
-purge_isolated
+random_reorder
+snap_converter
 to_edge_list

--- a/utils/makefile
+++ b/utils/makefile
@@ -1,60 +1,16 @@
-# TODO(tomtseng): update this file to include the snap converter and to use
-# makefile.variables
-# see BUILD file to see the binaries that actually build
+# Builds binaries in utils/.
 
-ifeq (, $(shell which jemalloc-config))
-JEMALLOC =
-else
-JEMALLOCLD = $(shell jemalloc-config --libdir)
-JEMALLOC = -L$(JEMALLOCLD) -ljemalloc
-endif
+# git root directory
+ROOTDIR = $(strip $(shell git rev-parse --show-cdup))
 
-# Always compile with LONG (note that timings on small graphs may be a bit
-# faster w/o this flag).
-INTT = -DLONG
+include $(ROOTDIR)makefile.variables
 
-ifdef EDGELONG
-INTE = -DEDGELONG
-endif
+ALL = \
+	compressor \
+	converter \
+	random_reorder \
+	to_edge_list \
+	snap_converter
 
-INCLUDE_DIRS = -I../ -I../ligra
-
-OPT = -O3 -g -DNDEBUG
-
-CFLAGS = $(INCLUDE_DIRS) -I../src -mcx16 -ldl -std=c++17 -march=native -Wall $(OPT) $(INTT) $(INTE) -DAMORTIZEDPD $(CONCEPTS) -DUSEMALLOC -DNDEBUG
-
-OMPFLAGS = -DOPENMP -fopenmp
-CILKFLAGS = -DCILK -fcilkplus
-HGFLAGS = -DHOMEGROWN -pthread
-
-ifdef CLANG
-CC = clang++
-PFLAGS = $(CILKFLAGS)
-else ifdef CILK
-CC = g++
-PFLAGS = $(CILKFLAGS)
-else ifdef OPENMP
-CC = g++
-PFLAGS = $(OMPFLAGS)
-else ifdef HOMEGROWN
-CC = g++
-PFLAGS = $(HGFLAGS)
-else ifdef SERIAL
-CC = g++
-PFLAGS =
-else # default is homegrown
-CC = g++
-PFLAGS = $(HGFLAGS)
-endif
-
-ALL= add_weights converter compressor gen_torus random_reorder to_edge_list pure_isolated check_symmetric
-
-all: $(ALL)
-
-% : %.C
-	$(CC) $(CFLAGS) $(PFLAGS) -o $@ $<
-
-.PHONY : clean
-
-clean :
-	rm -f *.o $(ALL)
+# These aren't benchmarks but they can't be built in the same fashion.
+include $(ROOTDIR)benchmarks/makefile.benchmarks

--- a/utils/makefile
+++ b/utils/makefile
@@ -12,5 +12,5 @@ ALL = \
 	to_edge_list \
 	snap_converter
 
-# These aren't benchmarks but they can't be built in the same fashion.
+# These aren't benchmarks, but they can be built in the same fashion.
 include $(ROOTDIR)benchmarks/makefile.benchmarks


### PR DESCRIPTION
Add Makefile for `utils/`, not including `utils/generators/`.

Other changes:
- Added `--start-group` and `--end-group` around linker objects in `makefile.benchmarks` to crudely fix link-order issues that appeared