### PR TITLE
SCAN: Add second implementation for correctness checking

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 /benchmarks/SCAN/IndexBased/ @tomtseng
+/benchmarks/SCAN/Naive/ @tomtseng

--- a/benchmarks/SCAN/Naive/BUILD
+++ b/benchmarks/SCAN/Naive/BUILD
@@ -1,0 +1,21 @@
+cc_library(
+    name = "scan",
+    srcs = [
+    ],
+    hdrs = [
+        "scan.h",
+        "scan_helpers.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ligra",
+        "//ligra:graph",
+        "//ligra:macros",
+        "//ligra:undirected_edge",
+        "//ligra:vertex_subset",
+        "//ligra/pbbslib:sparse_table",
+        "//pbbslib:seq",
+        "//pbbslib:stlalgs",
+        "//pbbslib:utilities",
+    ],
+)

--- a/benchmarks/SCAN/Naive/BUILD
+++ b/benchmarks/SCAN/Naive/BUILD
@@ -1,6 +1,7 @@
 cc_library(
     name = "scan",
     srcs = [
+        "scan_helpers.cc",
     ],
     hdrs = [
         "scan.h",

--- a/benchmarks/SCAN/Naive/scan.h
+++ b/benchmarks/SCAN/Naive/scan.h
@@ -1,0 +1,112 @@
+// A simple implementation of SCAN.
+//
+// This implementation doesn't attempt to be fast but is useful for checking
+// correctness of other SCAN implementations.
+#pragma once
+
+#include <functional>
+
+#include "benchmarks/SCAN/Naive/scan_helpers.h"
+#include "ligra/graph.h"
+#include "ligra/ligra.h"
+#include "ligra/macros.h"
+#include "ligra/vertex_subset.h"
+#include "pbbslib/seq.h"
+#include "pbbslib/stlalgs.h"
+#include "pbbslib/utilities.h"
+
+namespace naive_scan {
+
+// We represent a clustering on an n-vertex graph by an n-length sequence S such
+// that S[i] is the IDs of clusters that vertex i is in. Some vertices might not
+// be a member of any cluster, and some "border" vertices may be a member of
+// many clusters.
+using Clustering = pbbs::sequence<pbbs::sequence<uintE>>;
+
+// Compute a SCAN clustering of a graph using SCAN parameters mu and epsilon.
+template <template <typename> class VertexTemplate>
+Clustering Cluster(
+    symmetric_graph<VertexTemplate, pbbslib::empty>* graph,
+    const uint64_t mu,
+    const float epsilon) {
+  const size_t num_vertices{graph->n};
+  Clustering clustering(graph->n, pbbs::sequence<uintE>{});
+
+  internal::StructuralSimilarities
+    similarities{internal::ComputeStructuralSimilarities(graph)};
+  const auto neighbor_has_epsilon_similarity{
+    [&](const uintE u, const uintE v, internal::NoWeight) {
+        constexpr float defaultSimilarity{-1};
+      return
+        similarities.find(UndirectedEdge{u, v}, defaultSimilarity)
+        >= epsilon;
+    }};
+  const pbbs::sequence<bool> core_bitmap(
+      num_vertices,
+      [&](const size_t i) {
+        return
+          graph->get_vertex(i)
+            .countOutNgh(i, neighbor_has_epsilon_similarity) >= mu;
+      });
+  const auto is_core{[&](const uintE v) { return core_bitmap[v]; }};
+  // Cluster all the cores by running BFS on the more-than-epsilon-similar edges
+  // of the core vertices.
+  for (uintE root = 0; root < num_vertices; root++) {
+    if (!clustering[root].empty()) {
+      continue;
+    }
+    const auto update_clustering_for_cores{[&](const uintE v) {
+      clustering[v] = pbbs::sequence<uintE>(1, root);
+    }};
+
+    vertexSubset frontier(num_vertices, root);
+    while (!frontier.isEmpty()) {
+      vertexSubset core_frontier =
+        frontier.isDense
+        ? vertexFilter(frontier, is_core)
+        : vertexFilter2(frontier, is_core);
+      vertexMap(core_frontier, update_clustering_for_cores);
+
+      vertexSubset next_frontier{edgeMap(
+          *graph,
+          core_frontier,
+          internal::CoreBFSEdgeMapFunctions{similarities, clustering})};
+      frontier.del();
+      core_frontier.del();
+      frontier = std::move(next_frontier);
+    }
+    frontier.del();
+  }
+
+  const auto is_core_neighbor{
+    [&](const std::tuple<uintE, internal::NoWeight> neighbor) {
+      return core_bitmap[std::get<0>(neighbor)];
+    }};
+  const auto get_core_cluster{
+    [&](const std::tuple<uintE, internal::NoWeight> neighbor) {
+      return clustering[std::get<0>(neighbor)][0];
+    }};
+  // Cluster all the non-cores by attaching them to the clusters of neighboring
+  // cores.
+  par_for(0, num_vertices, [&](const size_t vertex_id) {
+    if (clustering[vertex_id].empty()) {
+      auto vertex{graph->get_vertex(vertex_id)};
+      const uintE degree{vertex.getOutDegree()};
+      std::tuple<uintE, internal::NoWeight>*
+        neighbors{vertex.getOutNeighbors()};
+      const sequence<std::tuple<uintE, internal::NoWeight>> core_neighbors{
+        filter(
+            pbbs::range<std::tuple<uintE, internal::NoWeight>*>{
+              neighbors, neighbors + degree},
+            is_core_neighbor)};
+      const sequence<uintE> neighboring_clusters{
+        pbbs::map<uintE>(core_neighbors, get_core_cluster)};
+      clustering[vertex_id] =
+        pbbs::remove_duplicates_ordered(neighboring_clusters, std::less<uintE>{});
+    }
+  });
+
+  return clustering;
+}
+
+}  // namespace naive_scan

--- a/benchmarks/SCAN/Naive/scan.h
+++ b/benchmarks/SCAN/Naive/scan.h
@@ -68,6 +68,7 @@ Clustering Cluster(
         frontier.isDense
         ? vertexFilter(frontier, is_core)
         : vertexFilter2(frontier, is_core);
+      internal::RemoveDuplicates(&core_frontier);
       vertexMap(core_frontier, update_clustering_for_cores);
 
       vertexSubset next_frontier{edgeMap(

--- a/benchmarks/SCAN/Naive/scan.h
+++ b/benchmarks/SCAN/Naive/scan.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <functional>
+#include <tuple>
+#include <utility>
 
 #include "benchmarks/SCAN/Naive/scan_helpers.h"
 #include "ligra/graph.h"
@@ -101,8 +103,8 @@ Clustering Cluster(
             is_core_neighbor)};
       const sequence<uintE> neighboring_clusters{
         pbbs::map<uintE>(core_neighbors, get_core_cluster)};
-      clustering[vertex_id] =
-        pbbs::remove_duplicates_ordered(neighboring_clusters, std::less<uintE>{});
+      clustering[vertex_id] = pbbs::remove_duplicates_ordered(
+          neighboring_clusters, std::less<uintE>{});
     }
   });
 

--- a/benchmarks/SCAN/Naive/scan.h
+++ b/benchmarks/SCAN/Naive/scan.h
@@ -38,10 +38,8 @@ Clustering Cluster(
     similarities{internal::ComputeStructuralSimilarities(graph)};
   const auto neighbor_has_epsilon_similarity{
     [&](const uintE u, const uintE v, internal::NoWeight) {
-        constexpr float defaultSimilarity{-1};
-      return
-        similarities.find(UndirectedEdge{u, v}, defaultSimilarity)
-        >= epsilon;
+      constexpr float defaultSimilarity{-1.0};
+      return similarities.find({u, v}, defaultSimilarity) >= epsilon;
     }};
   const pbbs::sequence<bool> core_bitmap(
       num_vertices,
@@ -72,7 +70,8 @@ Clustering Cluster(
       vertexSubset next_frontier{edgeMap(
           *graph,
           core_frontier,
-          internal::CoreBFSEdgeMapFunctions{similarities, clustering})};
+          internal::CoreBFSEdgeMapFunctions{
+            similarities, clustering, epsilon})};
       frontier.del();
       core_frontier.del();
       frontier = std::move(next_frontier);

--- a/benchmarks/SCAN/Naive/scan_helpers.cc
+++ b/benchmarks/SCAN/Naive/scan_helpers.cc
@@ -1,6 +1,9 @@
 #include "benchmarks/SCAN/Naive/scan_helpers.h"
 
+#include <functional>
 #include <limits>
+
+#include "pbbslib/stlalgs.h"
 
 namespace naive_scan {
 
@@ -30,6 +33,22 @@ bool CoreBFSEdgeMapFunctions::updateAtomic(
 bool CoreBFSEdgeMapFunctions::cond(const uintE v) const {
   return current_clustering_[v].empty();
 }
+
+void RemoveDuplicates(vertexSubset* vertex_subset) {
+  if (vertex_subset->isDense) {
+    return;
+  }
+  pbbs::sequence<uintE> vertices(
+      vertex_subset->size(),
+      [&](const size_t i) { return vertex_subset->vtx(i); });
+  pbbs::sequence<uintE> deduped_vertices{
+    pbbs::remove_duplicates_ordered(vertices, std::less<uintE>{})};
+  vertexSubset deduped_vertex_subset{
+    vertex_subset->n, std::move(deduped_vertices)};
+  vertex_subset->del();
+  *vertex_subset = deduped_vertex_subset;
+}
+
 
 }  // namespace internal
 

--- a/benchmarks/SCAN/Naive/scan_helpers.cc
+++ b/benchmarks/SCAN/Naive/scan_helpers.cc
@@ -1,0 +1,29 @@
+#include "benchmarks/SCAN/Naive/scan_helpers.h"
+
+namespace naive_scan {
+
+namespace internal {
+
+CoreBFSEdgeMapFunctions::CoreBFSEdgeMapFunctions(
+    const StructuralSimilarities& similarities,
+    const Clustering& current_clustering) 
+  : similarities_{similarities}
+  , current_clustering_{current_clustering} {}
+
+bool 
+CoreBFSEdgeMapFunctions::update(const uintE u, const uintE v, NoWeight) const {
+  return current_clustering_[v].empty();
+}
+
+bool CoreBFSEdgeMapFunctions::updateAtomic(
+    const uintE u, const uintE v, NoWeight) const {
+  return current_clustering_[v].empty();
+}
+
+bool CoreBFSEdgeMapFunctions::cond(const uintE v) const {
+  return current_clustering_[v].empty();
+}
+
+}  // namespace internal
+
+}  // namespace naive_scan

--- a/benchmarks/SCAN/Naive/scan_helpers.cc
+++ b/benchmarks/SCAN/Naive/scan_helpers.cc
@@ -1,5 +1,7 @@
 #include "benchmarks/SCAN/Naive/scan_helpers.h"
 
+#include <limits>
+
 namespace naive_scan {
 
 namespace internal {
@@ -14,7 +16,8 @@ CoreBFSEdgeMapFunctions::CoreBFSEdgeMapFunctions(
 
 bool
 CoreBFSEdgeMapFunctions::update(const uintE u, const uintE v, NoWeight) const {
-  constexpr float kDefaultSimilarity{-1.0};
+  constexpr float
+    kDefaultSimilarity{std::numeric_limits<float>::signaling_NaN()};
   return current_clustering_[v].empty()
     && similarities_.find({u, v}, kDefaultSimilarity) >= epsilon_;
 }

--- a/benchmarks/SCAN/Naive/scan_helpers.cc
+++ b/benchmarks/SCAN/Naive/scan_helpers.cc
@@ -6,11 +6,11 @@ namespace internal {
 
 CoreBFSEdgeMapFunctions::CoreBFSEdgeMapFunctions(
     const StructuralSimilarities& similarities,
-    const Clustering& current_clustering) 
+    const Clustering& current_clustering)
   : similarities_{similarities}
   , current_clustering_{current_clustering} {}
 
-bool 
+bool
 CoreBFSEdgeMapFunctions::update(const uintE u, const uintE v, NoWeight) const {
   return current_clustering_[v].empty();
 }

--- a/benchmarks/SCAN/Naive/scan_helpers.cc
+++ b/benchmarks/SCAN/Naive/scan_helpers.cc
@@ -6,18 +6,22 @@ namespace internal {
 
 CoreBFSEdgeMapFunctions::CoreBFSEdgeMapFunctions(
     const StructuralSimilarities& similarities,
-    const Clustering& current_clustering)
+    const Clustering& current_clustering,
+    const float epsilon)
   : similarities_{similarities}
-  , current_clustering_{current_clustering} {}
+  , current_clustering_{current_clustering}
+  , epsilon_{epsilon} {}
 
 bool
 CoreBFSEdgeMapFunctions::update(const uintE u, const uintE v, NoWeight) const {
-  return current_clustering_[v].empty();
+  constexpr float kDefaultSimilarity{-1.0};
+  return current_clustering_[v].empty()
+    && similarities_.find({u, v}, kDefaultSimilarity) >= epsilon_;
 }
 
 bool CoreBFSEdgeMapFunctions::updateAtomic(
     const uintE u, const uintE v, NoWeight) const {
-  return current_clustering_[v].empty();
+  return update(u, v, NoWeight{});
 }
 
 bool CoreBFSEdgeMapFunctions::cond(const uintE v) const {

--- a/benchmarks/SCAN/Naive/scan_helpers.h
+++ b/benchmarks/SCAN/Naive/scan_helpers.h
@@ -1,0 +1,115 @@
+// Helper functions for SCAN logic that shouldn't clutter the main SCAN
+// header file.
+
+#include <utility>
+
+#include "ligra/graph.h"
+#include "ligra/macros.h"
+#include "ligra/pbbslib/sparse_table.h"
+#include "ligra/undirected_edge.h"
+#include "pbbslib/seq.h"
+#include "pbbslib/utilities.h"
+
+namespace naive_scan {
+
+using Clustering = pbbs::sequence<pbbs::sequence<uintE>>;
+
+namespace internal {  // internal declarations
+
+using StructuralSimilarities =
+  sparse_table<UndirectedEdge, float, std::hash<UndirectedEdge>>;
+using NoWeight = pbbslib::empty;
+
+class CoreBFSEdgeMapFunctions {
+ public:
+  CoreBFSEdgeMapFunctions(
+      const StructuralSimilarities& similarities,
+      const Clustering& current_clustering);
+
+  bool update(uintE, uintE, NoWeight) const;
+  bool updateAtomic(uintE, uintE, NoWeight) const;
+  bool cond(uintE) const;
+
+ private:
+  const StructuralSimilarities& similarities_;
+  const Clustering& current_clustering_;
+};
+
+// Compute structural similarities (as defined by SCAN) between each pair of
+// adjacent vertices.
+//
+// The structural similarity between two vertices u and v is
+//   (size of intersection of closed neighborhoods of u and v) /
+//   (geometric mean of size of closed neighborhoods of u and of v)
+// where the closed neighborhood of a vertex x consists of all neighbors of x
+// along with x itself.
+template <template <typename WeightType> class VertexType>
+StructuralSimilarities
+ComputeStructuralSimilarities(symmetric_graph<VertexType, NoWeight>* graph) {
+  using Vertex = VertexType<NoWeight>;
+  using VertexSet =
+    sparse_table<uintE, pbbslib::empty, decltype(&pbbslib::hash64_2)>;
+
+  StructuralSimilarities similarities{
+    graph->m,
+    std::make_pair(UndirectedEdge{UINT_E_MAX, UINT_E_MAX}, 0.0),
+    std::hash<UndirectedEdge>{}};
+
+  pbbs::sequence<VertexSet> adjacency_list{
+    pbbs::sequence<VertexSet>::no_init(graph->n)};
+
+  parallel_for(0, graph->n, [&graph, &adjacency_list](const size_t vertex_id) {
+    Vertex vertex{graph->get_vertex(vertex_id)};
+    auto* const neighbors{&adjacency_list[vertex_id]};
+    *neighbors = VertexSet{
+      vertex.getOutDegree(), 
+      {UINT_E_MAX, internal::NoWeight{}}, 
+      pbbslib::hash64_2};
+    const auto update_adjacency_list{[&neighbors](
+        uintE, const uintE neighbor, NoWeight) {
+      neighbors->insert({neighbor, pbbslib::empty{}});
+    }};
+    vertex.mapOutNgh(vertex_id, update_adjacency_list);
+  });
+
+  graph->map_edges([&graph, &adjacency_list, &similarities](
+        const uintE u_id, const uintE v_id, NoWeight) {
+      if (u_id < v_id) {
+        Vertex u{graph->get_vertex(u_id)};
+        Vertex v{graph->get_vertex(v_id)};
+        const auto& u_neighbors{adjacency_list[u_id]};
+        const auto& v_neighbors{adjacency_list[v_id]};
+
+        const bool u_degree_is_smaller{u.getOutDegree() < v.getOutDegree()};
+        const uintE smaller_degree_vertex_id{u_degree_is_smaller ? u_id : v_id};
+        Vertex* smaller_degree_vertex{u_degree_is_smaller ? &u : &v};
+        const auto& larger_degree_vertex_neighbors{
+          u_degree_is_smaller ? v_neighbors : u_neighbors
+        };
+
+        const auto is_shared_neighbor{
+          [&](uintE, const uintE neighbor, NoWeight) {
+            return larger_degree_vertex_neighbors.contains(neighbor);
+          }};
+        const auto addition_monoid{pbbslib::addm<size_t>()};
+        const size_t num_shared_neighbors{
+          smaller_degree_vertex->template reduceOutNgh<size_t>(
+              smaller_degree_vertex_id,
+              is_shared_neighbor,
+              addition_monoid)};
+
+        // The neighborhoods we've computed are open neighborhoods -- since
+        // structural similarity uses closed neighborhoods, we need to adjust
+        // the numbers slightly, hence the `+ 1` and `+ 2` terms.
+        similarities.insert(
+            {UndirectedEdge{u_id, v_id},
+            (num_shared_neighbors + 2) /
+                (sqrt(u.getOutDegree() + 1) * sqrt(v.getOutDegree() + 1))});
+      }
+  });
+  return similarities;
+}
+
+}  // namespace internal
+
+}  // namespace naive_scan

--- a/benchmarks/SCAN/Naive/scan_helpers.h
+++ b/benchmarks/SCAN/Naive/scan_helpers.h
@@ -25,7 +25,8 @@ class CoreBFSEdgeMapFunctions {
  public:
   CoreBFSEdgeMapFunctions(
       const StructuralSimilarities& similarities,
-      const Clustering& current_clustering);
+      const Clustering& current_clustering,
+      float epsilon);
 
   bool update(uintE, uintE, NoWeight) const;
   bool updateAtomic(uintE, uintE, NoWeight) const;
@@ -34,6 +35,7 @@ class CoreBFSEdgeMapFunctions {
  private:
   const StructuralSimilarities& similarities_;
   const Clustering& current_clustering_;
+  float epsilon_;
 };
 
 // Compute structural similarities (as defined by SCAN) between each pair of

--- a/benchmarks/SCAN/Naive/scan_helpers.h
+++ b/benchmarks/SCAN/Naive/scan_helpers.h
@@ -47,6 +47,9 @@ class CoreBFSEdgeMapFunctions {
 //   (geometric mean of size of closed neighborhoods of u and of v)
 // where the closed neighborhood of a vertex x consists of all neighbors of x
 // along with x itself.
+//
+// The neighbor lists for each vertex in the graph must be sorted by ascending
+// neighbor ID.
 template <template <typename WeightType> class VertexType>
 StructuralSimilarities
 ComputeStructuralSimilarities(symmetric_graph<VertexType, NoWeight>* graph) {
@@ -58,7 +61,6 @@ ComputeStructuralSimilarities(symmetric_graph<VertexType, NoWeight>* graph) {
     graph->m,
     std::make_pair(UndirectedEdge{UINT_E_MAX, UINT_E_MAX}, 0.0),
     std::hash<UndirectedEdge>{}};
-
   pbbs::sequence<VertexSet> adjacency_list{
     pbbs::sequence<VertexSet>::no_init(graph->n)};
 

--- a/benchmarks/SCAN/Naive/scan_helpers.h
+++ b/benchmarks/SCAN/Naive/scan_helpers.h
@@ -1,5 +1,6 @@
 // Helper functions for SCAN logic that shouldn't clutter the main SCAN
 // header file.
+#pragma once
 
 #include <utility>
 
@@ -62,8 +63,8 @@ ComputeStructuralSimilarities(symmetric_graph<VertexType, NoWeight>* graph) {
     Vertex vertex{graph->get_vertex(vertex_id)};
     auto* const neighbors{&adjacency_list[vertex_id]};
     *neighbors = VertexSet{
-      vertex.getOutDegree(), 
-      {UINT_E_MAX, internal::NoWeight{}}, 
+      vertex.getOutDegree(),
+      {UINT_E_MAX, internal::NoWeight{}},
       pbbslib::hash64_2};
     const auto update_adjacency_list{[&neighbors](
         uintE, const uintE neighbor, NoWeight) {

--- a/benchmarks/SCAN/Naive/scan_helpers.h
+++ b/benchmarks/SCAN/Naive/scan_helpers.h
@@ -8,6 +8,7 @@
 #include "ligra/macros.h"
 #include "ligra/pbbslib/sparse_table.h"
 #include "ligra/undirected_edge.h"
+#include "ligra/vertex_subset.h"
 #include "pbbslib/seq.h"
 #include "pbbslib/utilities.h"
 
@@ -112,6 +113,9 @@ ComputeStructuralSimilarities(symmetric_graph<VertexType, NoWeight>* graph) {
   });
   return similarities;
 }
+
+// Remove duplicate vertices from a vertex subset.
+void RemoveDuplicates(vertexSubset* vertex_subset);
 
 }  // namespace internal
 

--- a/benchmarks/SCAN/Naive/unit_tests/BUILD
+++ b/benchmarks/SCAN/Naive/unit_tests/BUILD
@@ -1,0 +1,11 @@
+cc_test(
+    name = "scan_test",
+    srcs = ["scan_test.cc"],
+    deps = [
+        "//benchmarks/SCAN/Naive:scan",
+        "//ligra:graph_test_utils",
+        "//ligra:undirected_edge",
+        "//pbbslib:seq",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
@@ -1,0 +1,251 @@
+#include "benchmarks/SCAN/Naive/scan.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "ligra/graph_test_utils.h"
+#include "ligra/undirected_edge.h"
+#include "pbbslib/seq.h"
+
+namespace gt = graph_test;
+namespace n = naive_scan;
+
+// Like naive_scan::Clustering, but using `std::vector` instead of
+// `pbbs::sequence` for convenience.
+using ExpectedClusters = std::vector<std::vector<uintE>>;
+
+namespace {
+
+// Checks that `clustering` has the expected clusters and returns true if the
+// check passes.
+bool CheckClustering(
+    const n::Clustering& actual_clusters,
+    const ExpectedClusters& expected_clusters) {
+  return false;
+}
+
+}  // namespace
+
+TEST(Cluster, NullGraph) {
+  const size_t kNumVertices{0};
+  const std::unordered_set<UndirectedEdge> kEdges{};
+  auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+
+  constexpr float kMu{2};
+  constexpr float kEpsilon{0.5};
+  const n::Clustering clusters{n::Cluster(&graph, kMu, kEpsilon)};
+  const ExpectedClusters expected_clusters{};
+  EXPECT_TRUE(CheckClustering(clusters, expected_clusters));
+}
+
+// TEST(Cluster, EmptyGraph) {
+//   const size_t kNumVertices{6};
+//   const std::unordered_set<UndirectedEdge> kEdges{};
+//   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+
+//   const i::Index index{&graph};
+//   constexpr float kMu{2};
+//   constexpr float kEpsilon{0.5};
+//   i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//   const ClusterList kExpectedClusters{};
+//   const VertexList kExpectedHubs{};
+//   const VertexList kExpectedOutliers{0, 1, 2, 3, 4, 5};
+//   EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//   CheckUnclusteredVertices(
+//       &graph, clustering, kExpectedHubs, kExpectedOutliers);
+// }
+
+// TEST(Cluster, BasicUsage) {
+//   // Graph diagram with structural similarity scores labeled:
+//   //       .71    .67  .63
+//   //     0 --- 1 ---- 2 -- 5
+//   //           |    / |
+//   //       .75 |  .89 | .77
+//   //           | /    |
+//   //           3 ---- 4
+//   //             .87
+//   const size_t kNumVertices{6};
+//   const std::unordered_set<UndirectedEdge> kEdges{
+//     {0, 1},
+//     {1, 2},
+//     {1, 3},
+//     {2, 3},
+//     {2, 4},
+//     {2, 5},
+//     {3, 4},
+//   };
+//   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+//   const i::Index index{&graph};
+
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.5};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{0, 1, 2, 3, 4, 5}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.7};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{0, 1, 2, 3, 4}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{5};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.73};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{1, 2, 3, 4}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{0, 5};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.88};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{2, 3}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{0, 1, 4, 5};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.95};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{0, 1, 2, 3, 4, 5};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{4};
+//     constexpr float kEpsilon{0.7};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{1, 2, 3, 4}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{0, 5};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+// }
+
+// TEST(Cluster, DisconnectedGraph) {
+//   // Graph diagram with structural similarity scores labeled:
+//   //       1.0            .82  .82
+//   //     0 -- 1    2    3 -- 4 -- 5
+//   const size_t kNumVertices{6};
+//   const std::unordered_set<UndirectedEdge> kEdges{
+//     {0, 1},
+//     {3, 4},
+//     {4, 5},
+//   };
+//   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+//   const i::Index index{&graph};
+
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.95};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{0, 1}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{2, 3, 4, 5};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.8};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{0, 1}, {3, 4, 5}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{2};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{3};
+//     constexpr float kEpsilon{0.8};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{3, 4, 5}};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{0, 1, 2};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+//   {
+//     constexpr uint64_t kMu{4};
+//     constexpr float kEpsilon{0.8};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{};
+//     const VertexList kExpectedHubs{};
+//     const VertexList kExpectedOutliers{0, 1, 2, 3, 4, 5};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+// }
+
+// TEST(Cluster, TwoClusterGraph) {
+//   // Graph diagram with structural similarity scores labeled:
+//   //           2                   6
+//   //     .87 /   \ .87       .87 /   \ .87
+//   //        /     \             /     \.
+//   // 0 --- 1 ----- 3 --- 4 --- 5 ----- 7 --- 8
+//   //   .71    .75    .58   .58    .75   .71
+//   const size_t kNumVertices{9};
+//   const std::unordered_set<UndirectedEdge> kEdges{
+//     {0, 1},
+//     {1, 2},
+//     {1, 3},
+//     {2, 3},
+//     {3, 4},
+//     {4, 5},
+//     {5, 6},
+//     {5, 7},
+//     {6, 7},
+//     {7, 8},
+//   };
+//   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+//   const i::Index index{&graph};
+//   {
+//     constexpr uint64_t kMu{2};
+//     constexpr float kEpsilon{0.73};
+//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+
+//     const ClusterList kExpectedClusters{{1, 2, 3}, {5, 6, 7}};
+//     const VertexList kExpectedHubs{4};
+//     const VertexList kExpectedOutliers{0, 8};
+//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClusters));
+//     CheckUnclusteredVertices(
+//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
+//   }
+// }

--- a/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
@@ -14,7 +14,7 @@
 namespace gt = graph_test;
 namespace n = naive_scan;
 
-// Like naive_scan::Clustering, but using `std::vector` instead of
+// Like naive_scan::Clustering, but uses `std::vector` instead of
 // `pbbs::sequence` for convenience.
 using ClusteringArray = std::vector<std::vector<uintE>>;
 
@@ -43,8 +43,7 @@ std::string ClusteringToString(const Clustering& clustering) {
   return str.str();
 }
 
-// Checks that `clustering` has the expected clusters and returns true if the
-// check passes.
+// Checks that `actual_clustering` has the expected clusters.
 void CheckClustering(
     const n::Clustering& actual_clustering,
     const ClusteringArray& expected_clustering) {

--- a/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
@@ -259,12 +259,22 @@ TEST(Cluster, TwoClusterGraph) {
   };
   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
 
+  {
+    constexpr uint64_t kMu{2};
+    constexpr float kEpsilon{0.73};
+    const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
 
-  constexpr uint64_t kMu{2};
-  constexpr float kEpsilon{0.73};
-  const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
+    const ClusteringArray kExpectedClustering{
+      {}, {0}, {0}, {0}, {}, {1}, {1}, {1}, {}};
+    CheckClustering(clustering, kExpectedClustering);
+  }
+  {
+    constexpr uint64_t kMu{4};
+    constexpr float kEpsilon{0.5};
+    const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
 
-  const ClusteringArray kExpectedClustering{
-    {}, {0}, {0}, {0}, {}, {1}, {1}, {1}, {}};
-  CheckClustering(clustering, kExpectedClustering);
+    const ClusteringArray kExpectedClustering{
+      {0}, {0}, {0}, {0}, {0, 1}, {1}, {1}, {1}, {1}};
+    CheckClustering(clustering, kExpectedClustering);
+  }
 }

--- a/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
@@ -187,101 +187,84 @@ TEST(Cluster, BasicUsage) {
   }
 }
 
-// TEST(Cluster, DisconnectedGraph) {
-//   // Graph diagram with structural similarity scores labeled:
-//   //       1.0            .82  .82
-//   //     0 -- 1    2    3 -- 4 -- 5
-//   const size_t kNumVertices{6};
-//   const std::unordered_set<UndirectedEdge> kEdges{
-//     {0, 1},
-//     {3, 4},
-//     {4, 5},
-//   };
-//   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
-//   const i::Index index{&graph};
+TEST(Cluster, DisconnectedGraph) {
+  // Graph diagram with structural similarity scores labeled:
+  //       1.0            .82  .82
+  //     0 -- 1    2    3 -- 4 -- 5
+  const size_t kNumVertices{6};
+  const std::unordered_set<UndirectedEdge> kEdges{
+    {0, 1},
+    {3, 4},
+    {4, 5},
+  };
+  auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
 
-//   {
-//     constexpr uint64_t kMu{2};
-//     constexpr float kEpsilon{0.95};
-//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+  {
+    constexpr uint64_t kMu{2};
+    constexpr float kEpsilon{0.95};
+    const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
 
-//     const ClusterList kExpectedClustering{{0, 1}};
-//     const VertexList kExpectedHubs{};
-//     const VertexList kExpectedOutliers{2, 3, 4, 5};
-//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClustering));
-//     CheckUnclusteredVertices(
-//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
-//   }
-//   {
-//     constexpr uint64_t kMu{2};
-//     constexpr float kEpsilon{0.8};
-//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+    const ClusteringArray kExpectedClustering{
+      {0}, {0}, {}, {}, {}, {}};
+    CheckClustering(clustering, kExpectedClustering);
+  }
+  {
+    constexpr uint64_t kMu{2};
+    constexpr float kEpsilon{0.8};
+    const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
 
-//     const ClusterList kExpectedClustering{{0, 1}, {3, 4, 5}};
-//     const VertexList kExpectedHubs{};
-//     const VertexList kExpectedOutliers{2};
-//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClustering));
-//     CheckUnclusteredVertices(
-//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
-//   }
-//   {
-//     constexpr uint64_t kMu{3};
-//     constexpr float kEpsilon{0.8};
-//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+    const ClusteringArray kExpectedClustering{
+      {0}, {0}, {}, {1}, {1}, {1}};
+    CheckClustering(clustering, kExpectedClustering);
+  }
+  {
+    constexpr uint64_t kMu{3};
+    constexpr float kEpsilon{0.8};
+    const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
 
-//     const ClusterList kExpectedClustering{{3, 4, 5}};
-//     const VertexList kExpectedHubs{};
-//     const VertexList kExpectedOutliers{0, 1, 2};
-//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClustering));
-//     CheckUnclusteredVertices(
-//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
-//   }
-//   {
-//     constexpr uint64_t kMu{4};
-//     constexpr float kEpsilon{0.8};
-//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+    const ClusteringArray kExpectedClustering{
+      {}, {}, {}, {0}, {0}, {0}};
+    CheckClustering(clustering, kExpectedClustering);
+  }
+  {
+    constexpr uint64_t kMu{4};
+    constexpr float kEpsilon{0.8};
+    const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
 
-//     const ClusterList kExpectedClustering{};
-//     const VertexList kExpectedHubs{};
-//     const VertexList kExpectedOutliers{0, 1, 2, 3, 4, 5};
-//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClustering));
-//     CheckUnclusteredVertices(
-//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
-//   }
-// }
+    const ClusteringArray kExpectedClustering(
+      kNumVertices, std::vector<uintE>{});
+    CheckClustering(clustering, kExpectedClustering);
+  }
+}
 
-// TEST(Cluster, TwoClusterGraph) {
-//   // Graph diagram with structural similarity scores labeled:
-//   //           2                   6
-//   //     .87 /   \ .87       .87 /   \ .87
-//   //        /     \             /     \.
-//   // 0 --- 1 ----- 3 --- 4 --- 5 ----- 7 --- 8
-//   //   .71    .75    .58   .58    .75   .71
-//   const size_t kNumVertices{9};
-//   const std::unordered_set<UndirectedEdge> kEdges{
-//     {0, 1},
-//     {1, 2},
-//     {1, 3},
-//     {2, 3},
-//     {3, 4},
-//     {4, 5},
-//     {5, 6},
-//     {5, 7},
-//     {6, 7},
-//     {7, 8},
-//   };
-//   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
-//   const i::Index index{&graph};
-//   {
-//     constexpr uint64_t kMu{2};
-//     constexpr float kEpsilon{0.73};
-//     const i::Clustering clustering{index.Cluster(kMu, kEpsilon)};
+TEST(Cluster, TwoClusterGraph) {
+  // Graph diagram with structural similarity scores labeled:
+  //           2                   6
+  //     .87 /   \ .87       .87 /   \ .87
+  //        /     \             /     \.
+  // 0 --- 1 ----- 3 --- 4 --- 5 ----- 7 --- 8
+  //   .71    .75    .58   .58    .75   .71
+  const size_t kNumVertices{9};
+  const std::unordered_set<UndirectedEdge> kEdges{
+    {0, 1},
+    {1, 2},
+    {1, 3},
+    {2, 3},
+    {3, 4},
+    {4, 5},
+    {5, 6},
+    {5, 7},
+    {6, 7},
+    {7, 8},
+  };
+  auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
 
-//     const ClusterList kExpectedClustering{{1, 2, 3}, {5, 6, 7}};
-//     const VertexList kExpectedHubs{4};
-//     const VertexList kExpectedOutliers{0, 8};
-//     EXPECT_TRUE(CheckClustering(clustering, kExpectedClustering));
-//     CheckUnclusteredVertices(
-//         &graph, clustering, kExpectedHubs, kExpectedOutliers);
-//   }
-// }
+
+  constexpr uint64_t kMu{2};
+  constexpr float kEpsilon{0.73};
+  const n::Clustering clustering{n::Cluster(&graph, kMu, kEpsilon)};
+
+  const ClusteringArray kExpectedClustering{
+    {}, {0}, {0}, {0}, {}, {1}, {1}, {1}, {}};
+  CheckClustering(clustering, kExpectedClustering);
+}

--- a/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/Naive/unit_tests/scan_test.cc
@@ -64,8 +64,8 @@ void CheckClustering(
       if (it == cluster_map.end()) {
         cluster_map.emplace(actual_cluster_id, expected_cluster_id);
       } else {
-        // If mapping for this cluster ID already exists, it must be consistent
-        // with e
+        // If a mapping for this cluster ID already exists, it must be
+        // consistent with `expected_clustering`.
         EXPECT_EQ(it->second, expected_cluster_id);
       }
     }


### PR DESCRIPTION
Add `benchmarks/SCAN/Naive`, an implementation of SCAN. 

This implementation doesn't attempt to be fast but is useful for checking correctness of other SCAN implementations (namely, I used it to check the output of `benchmarks/SCAN/IndexBased`. However, when comparing outputs of different SCAN implementations, be wary of floating point rounding differences if there are pairs of vertices whose structural similarity falls very close to the SCAN epsilon value. For this kind of comparison, it's better to set epsilon to a non-round number like 0.603 rather than 0.6 to reduce the chance of encountering these issues.