### PR TITLE
seq: Add initializer list constructor

### DIFF
--- a/pbbslib/seq.h
+++ b/pbbslib/seq.h
@@ -186,7 +186,7 @@ struct sequence {
     copy_here(a, a.size());
   }
 
-  sequence(std::initializer_list<T> list) __attribute__((deprecated)) {
+  sequence(std::initializer_list<T> list) {
     n = list.size();
     s = pbbs::new_array_no_init<T>(n);
     size_t i{0};

--- a/pbbslib/seq.h
+++ b/pbbslib/seq.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <assert.h>
+
+#include <initializer_list>
+
 #include "utilities.h"
 
 #ifdef CONCEPTS
@@ -181,6 +184,16 @@ struct sequence {
   template <class F>
   sequence(delayed_sequence<T, F> a) {
     copy_here(a, a.size());
+  }
+
+  sequence(std::initializer_list<T> list) __attribute__((deprecated)) {
+    n = list.size();
+    s = pbbs::new_array_no_init<T>(n);
+    size_t i{0};
+    for (const auto& element : list) {
+      s[i] = element;
+      ++i;
+    }
   }
 
   ~sequence() { clear(); }


### PR DESCRIPTION
Add initializer list constructor for sequence. This is useful for unit tests --- now sequences can be initialized like 
```cpp
pbbs::sequence<int> s1 = {1, 2, 3, 4, 5};
```
just like `std::vector`s can. 

One annoyance with initializer list constructors is their ambiguity with brace initialization:
```cpp
// Before adding the initializer list constructor, this would call the (size_t)
// constructor and create a sequence of 100 elements.
// After adding the initializer list constructor, this calls the
// (initializer_list<size_t>) constructor and creates a sequence of a single
// element, 100.
pbbs::sequence<size_t> s{100};
```

To check that adding this constructor doesn't change the behavior of any existing brace initializations, I checked that adding ` __attribute__((deprecated))` to the initializer list constructor doesn't generate any warnings.