### PR TITLE
SCAN/IndexBased: Add modularity implementation

### DIFF
--- a/benchmarks/SCAN/IndexBased/BUILD
+++ b/benchmarks/SCAN/IndexBased/BUILD
@@ -42,7 +42,8 @@ cc_library(
         "//ligra:bridge",
         "//ligra:graph",
         "//ligra:macros",
-        "//pbbslib:integer_sort",
+        "//pbbslib:collect_reduce",
+        "//pbbslib:monoid",
         "//pbbslib:seq",
     ],
 )

--- a/benchmarks/SCAN/IndexBased/BUILD
+++ b/benchmarks/SCAN/IndexBased/BUILD
@@ -37,9 +37,12 @@ cc_library(
     hdrs = [
         "utils.h",
     ],
+    visibility = ["//visibility:public"],
     deps = [
+        "//ligra:bridge",
         "//ligra:graph",
         "//ligra:macros",
+        "//pbbslib:integer_sort",
         "//pbbslib:seq",
     ],
 )

--- a/benchmarks/SCAN/IndexBased/BUILD
+++ b/benchmarks/SCAN/IndexBased/BUILD
@@ -11,6 +11,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":utils",
         "//benchmarks/Connectivity/UnionFind:union_find_rules",
         "//benchmarks/TriangleCounting/ShunTangwongsan15:Triangle_main",
         "//ligra:bridge",
@@ -25,6 +26,21 @@ cc_library(
         "//pbbslib:sample_sort",
         "//pbbslib:seq",
         "//pbbslib:utilities",
+    ],
+)
+
+cc_library(
+    name = "utils",
+    srcs = [
+        "utils.cc",
+    ],
+    hdrs = [
+        "utils.h",
+    ],
+    deps = [
+        "//ligra:graph",
+        "//ligra:macros",
+        "//pbbslib:seq",
     ],
 )
 

--- a/benchmarks/SCAN/IndexBased/scan.h
+++ b/benchmarks/SCAN/IndexBased/scan.h
@@ -1,26 +1,13 @@
 #pragma once
 
-#include <string>
-
 #include "benchmarks/SCAN/IndexBased/scan_helpers.h"
+#include "benchmarks/SCAN/IndexBased/utils.h"
 #include "ligra/graph.h"
-#include "ligra/macros.h"
-#include "pbbslib/seq.h"
-#include "pbbslib/utilities.h"
 
 namespace indexed_scan {
 
-using Clustering = pbbs::sequence<uintE>;
-
-// Value in `Clustering` for a vertex that does not belong to any cluster.
-constexpr uintE kUnclustered{UINT_E_MAX};
-
-// Type of an unclustered vertex.
-enum class UnclusteredType {
-  kHub,  // Vertex is adjacent to two or more clusters.
-  kOutlier  // Vertex is adjacent to at most one cluster.
-};
-std::ostream& operator<<(std::ostream&, UnclusteredType);
+using scan::Clustering;
+using scan::kUnclustered;
 
 // Index for an undirected graph from which clustering the graph with SCAN is
 // quick, though index construction may be expensive.
@@ -67,51 +54,5 @@ class Index {
   const internal::NeighborOrder neighbor_order_;
   const internal::CoreOrder core_order_;
 };
-
-// Relabels `clustering` so that every cluster ID is in the range
-// [0, <number_of_clusters>) and returns the number of clusters.
-size_t CleanClustering(Clustering* clustering);
-
-// Converts clustering to a readable string.
-//
-// We don't write a `operator<<` overload because `Clustering` is an alias for a
-// more general type that isn't necessarily printed in the same way.
-std::string ClusteringToString(const Clustering& clustering);
-
-// Determines what type of unclustered vertex the input vertex is.
-//
-// Arguments:
-//   clustering
-//     A clustering of the graph `graph`.
-//  vertex
-//    The vertex of interest.
-//  vertex_id
-//     Vertex ID of the vertex of interest. `clustering[vertex_id]` should be
-//     `kUnclustered`.
-template <class Vertex>
-UnclusteredType DetermineUnclusteredType(
-    const Clustering& clustering, Vertex vertex, uintE vertex_id) {
-  bool is_hub{false};
-  // `candidate_cluster` holds a cluster ID that vertex i is adjacent to, or
-  // `kUnclustered` before such a cluster is found.
-  uintE candidate_cluster{kUnclustered};
-  const auto check_neighbor{[&](
-      const uintE v_id, const uintE neighbor_id, internal::NoWeight) {
-    const uintE neighbor_cluster{clustering[neighbor_id]};
-    // If `candidate_cluster` is at its default value of `kUnclustered`, assign
-    // `neighbor_cluster` to it. Otherwise, if it has a value differing from
-    // `neighbor_cluster`, then we know vertex i is adjacent to multiple
-    // clusters and is a hub.
-    if (neighbor_cluster != kUnclustered &&
-        !(candidate_cluster == UINT_E_MAX &&
-          pbbs::atomic_compare_and_swap(
-                  &candidate_cluster, UINT_E_MAX, neighbor_cluster)) &&
-        candidate_cluster != neighbor_cluster && !is_hub) {
-      is_hub = true;
-    }
-  }};
-  vertex.mapOutNgh(vertex_id, check_neighbor);
-  return is_hub ? UnclusteredType::kHub : UnclusteredType::kOutlier;
-}
 
 }  // namespace indexed_scan

--- a/benchmarks/SCAN/IndexBased/unit_tests/BUILD
+++ b/benchmarks/SCAN/IndexBased/unit_tests/BUILD
@@ -11,3 +11,15 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "utils_test",
+    srcs = ["utils_test.cc"],
+    deps = [
+        "//benchmarks/SCAN/IndexBased:utils",
+        "//ligra:graph",
+        "//ligra:graph_test_utils",
+        "//pbbslib:seq",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/benchmarks/SCAN/IndexBased/unit_tests/BUILD
+++ b/benchmarks/SCAN/IndexBased/unit_tests/BUILD
@@ -17,7 +17,6 @@ cc_test(
     srcs = ["utils_test.cc"],
     deps = [
         "//benchmarks/SCAN/IndexBased:utils",
-        "//ligra:graph",
         "//ligra:graph_test_utils",
         "//pbbslib:seq",
         "@googletest//:gtest_main",

--- a/benchmarks/SCAN/IndexBased/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/IndexBased/unit_tests/scan_test.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "benchmarks/SCAN/IndexBased/utils.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ligra/graph.h"
@@ -77,7 +78,7 @@ bool CheckClustering(
 
   if (actual_clusters != expected_clusters) {
     std::cerr << "Clusters don't match. Actual clustering:\n" <<
-      i::ClusteringToString(clustering) << '\n';
+      scan::ClusteringToString(clustering) << '\n';
     return false;
   } else {
     return true;
@@ -86,6 +87,9 @@ bool CheckClustering(
 
 // Checks that `DetermineUnclusteredType` identifies hubs and outliers as
 // expected.
+//
+// TODO(tomtseng): It would be cleaner to have a unit test that tests
+// `scan::DetermineUnclusteredType` separately instead of having this function.
 //
 // Arguments:
 //   graph
@@ -102,16 +106,16 @@ void CheckUnclusteredVertices(
     const VertexList& expected_hubs,
     const VertexList& expected_outliers) {
   for (const auto v : expected_hubs) {
-    EXPECT_EQ(clustering[v], i::kUnclustered);
+    EXPECT_EQ(clustering[v], scan::kUnclustered);
     EXPECT_EQ(
-        i::DetermineUnclusteredType(clustering, graph->get_vertex(v), v),
-        i::UnclusteredType::kHub);
+        scan::DetermineUnclusteredType(clustering, graph->get_vertex(v), v),
+        scan::UnclusteredType::kHub);
   }
   for (const auto v : expected_outliers) {
-    EXPECT_EQ(clustering[v], i::kUnclustered);
+    EXPECT_EQ(clustering[v], scan::kUnclustered);
     EXPECT_EQ(
-        i::DetermineUnclusteredType(clustering, graph->get_vertex(v), v),
-        i::UnclusteredType::kOutlier);
+        scan::DetermineUnclusteredType(clustering, graph->get_vertex(v), v),
+        scan::UnclusteredType::kOutlier);
   }
 }
 

--- a/benchmarks/SCAN/IndexBased/unit_tests/utils_test.cc
+++ b/benchmarks/SCAN/IndexBased/unit_tests/utils_test.cc
@@ -1,0 +1,38 @@
+#include "benchmarks/SCAN/IndexBased/utils.h"
+
+#include <unordered_set>
+
+#include "benchmarks/SCAN/IndexBased/utils.h"
+#include "gtest/gtest.h"
+#include "ligra/graph.h"
+#include "ligra/graph_test_utils.h"
+#include "pbbslib/seq.h"
+
+namespace gt = graph_test;
+
+TEST(Modularity, NullGraph) {
+  constexpr size_t kNumVertices{0};
+  const std::unordered_set<UndirectedEdge> kEdges{};
+  auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+  const scan::Clustering clusters{};
+  constexpr uintE kMaxClusterId{0};
+
+  EXPECT_EQ(scan::Modularity(&graph, clusters, kMaxClusterId), 0.0);
+}
+
+TEST(Modularity, EmptyGraph) {
+  constexpr size_t kNumVertices{6};
+  const std::unordered_set<UndirectedEdge> kEdges{};
+  auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+
+  {
+    const scan::Clustering clusters{0, 1, 2, 3, 4, 5};
+    constexpr uintE kMaxClusterId{kNumVertices};
+    EXPECT_EQ(scan::Modularity(&graph, clusters, kMaxClusterId), 0.0);
+  }
+  {
+    const scan::Clustering clusters(kNumVertices, scan::kUnclustered);
+    constexpr uintE kMaxClusterId{0};
+    EXPECT_EQ(scan::Modularity(&graph, clusters, kMaxClusterId), 0.0);
+  }
+}

--- a/benchmarks/SCAN/IndexBased/unit_tests/utils_test.cc
+++ b/benchmarks/SCAN/IndexBased/unit_tests/utils_test.cc
@@ -1,10 +1,6 @@
 #include "benchmarks/SCAN/IndexBased/utils.h"
 
-#include <unordered_set>
-
-#include "benchmarks/SCAN/IndexBased/utils.h"
 #include "gtest/gtest.h"
-#include "ligra/graph.h"
 #include "ligra/graph_test_utils.h"
 #include "pbbslib/seq.h"
 
@@ -15,24 +11,51 @@ TEST(Modularity, NullGraph) {
   const std::unordered_set<UndirectedEdge> kEdges{};
   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
   const scan::Clustering clusters{};
-  constexpr uintE kMaxClusterId{0};
-
-  EXPECT_EQ(scan::Modularity(&graph, clusters, kMaxClusterId), 0.0);
+  EXPECT_EQ(scan::Modularity(&graph, clusters), 0.0);
 }
 
 TEST(Modularity, EmptyGraph) {
   constexpr size_t kNumVertices{6};
   const std::unordered_set<UndirectedEdge> kEdges{};
   auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
+  const scan::Clustering clusters{0, 1, 2, 3, 4, 5};
+  EXPECT_EQ(scan::Modularity(&graph, clusters), 0.0);
+}
+
+TEST(Modularity, BasicGraph) {
+  // Graph diagram:
+  //   0               5
+  //   | \           / |
+  //   |  2 -- 3 -- 4  |
+  //   | /     |     \ |
+  //   1       7       6
+  //         /   \
+  //        8 --- 9
+  constexpr size_t kNumVertices{10};
+  const std::unordered_set<UndirectedEdge> kEdges{
+    {0, 1},
+    {0, 2},
+    {1, 2},
+    {2, 3},
+    {3, 4},
+    {3, 7},
+    {4, 5},
+    {4, 6},
+    {5, 6},
+    {7, 8},
+    {7, 9},
+    {8, 9},
+  };
+  auto graph{gt::MakeUnweightedSymmetricGraph(kNumVertices, kEdges)};
 
   {
-    const scan::Clustering clusters{0, 1, 2, 3, 4, 5};
-    constexpr uintE kMaxClusterId{kNumVertices};
-    EXPECT_EQ(scan::Modularity(&graph, clusters, kMaxClusterId), 0.0);
+    const scan::Clustering clusters{0, 0, 0, 0, 1, 1, 1, 2, 2, 2};
+    EXPECT_FLOAT_EQ(scan::Modularity(&graph, clusters), 0.48958333);
   }
-  {
-    const scan::Clustering clusters(kNumVertices, scan::kUnclustered);
-    constexpr uintE kMaxClusterId{0};
-    EXPECT_EQ(scan::Modularity(&graph, clusters, kMaxClusterId), 0.0);
+  {  // Test having unclustered vertices (vertices 3, 5, 6)
+    const scan::Clustering clusters{
+      0, 0, 0, scan::kUnclustered, 1, scan::kUnclustered, scan::kUnclustered,
+      2, 2, 2};
+    EXPECT_FLOAT_EQ(scan::Modularity(&graph, clusters), 0.28472222);
   }
 }

--- a/benchmarks/SCAN/IndexBased/utils.cc
+++ b/benchmarks/SCAN/IndexBased/utils.cc
@@ -1,0 +1,50 @@
+#include "benchmarks/SCAN/IndexBased/utils.h"
+
+#include <sstream>
+
+namespace scan {
+
+std::ostream& operator<<(std::ostream& os, UnclusteredType unclustered_type) {
+  switch (unclustered_type) {
+    case UnclusteredType::kHub:
+      os << "hub";
+      break;
+    case UnclusteredType::kOutlier:
+      os << "outlier";
+      break;
+  }
+  return os;
+}
+
+std::string ClusteringToString(const Clustering& clustering) {
+  std::ostringstream str;
+  str << "{";
+  for (size_t i = 0; i < clustering.size(); i++) {
+    str << ' ' << i << ':';
+    str << (clustering[i] == kUnclustered
+            ? "n/a" : std::to_string(clustering[i]));
+  }
+  str << " }";
+  return str.str();
+}
+
+size_t CompactClustering(Clustering* clustering) {
+  const size_t num_vertices{clustering->size()};
+  pbbs::sequence<uintE> cluster_relabel_map(num_vertices, 0U);
+  par_for(0, num_vertices, [&](const size_t i) {
+    const uintE cluster_id{(*clustering)[i]};
+    if (cluster_id != kUnclustered && cluster_relabel_map[cluster_id] == 0) {
+      cluster_relabel_map[cluster_id] = 1;
+    }
+  });
+  const size_t num_clusters{pbbslib::scan_add_inplace(cluster_relabel_map)};
+  par_for(0, num_vertices, [&](const size_t i) {
+    const uintE cluster_id{(*clustering)[i]};
+    if (cluster_id != kUnclustered) {
+      (*clustering)[i] = cluster_relabel_map[cluster_id];
+    }
+  });
+  return num_clusters;
+}
+
+}  // namespace scan

--- a/benchmarks/SCAN/IndexBased/utils.h
+++ b/benchmarks/SCAN/IndexBased/utils.h
@@ -1,0 +1,76 @@
+// Miscellaneous utility functions for SCAN. May be worth moving out of the
+// `SCAN/IndexBased` folder if we add other SCAN implementations.
+//
+// Here, a SCAN clustering is a partition of the vertices of a graph.
+#pragma once
+
+#include <iostream>
+#include <string>
+
+#include "ligra/graph.h"
+#include "ligra/macros.h"
+#include "pbbslib/seq.h"
+
+namespace scan {
+
+// A clustering is given by assigning each vertex a cluster ID.
+using Clustering = pbbs::sequence<uintE>;
+
+// Value in `Clustering` for a vertex that does not belong to any cluster.
+constexpr uintE kUnclustered{UINT_E_MAX};
+
+// Type of an unclustered vertex.
+enum class UnclusteredType {
+  kHub,  // Vertex is adjacent to two or more clusters.
+  kOutlier  // Vertex is adjacent to at most one cluster.
+};
+std::ostream& operator<<(std::ostream&, UnclusteredType);
+
+// Converts clustering to a readable string.
+//
+// We don't write a `operator<<` overload because `Clustering` is an alias for a
+// more general type that isn't necessarily printed in the same way.
+std::string ClusteringToString(const Clustering& clustering);
+
+// Given a clustering where each cluster ID is in the range `[0,
+// clustering->size())`, relabels the clustering so that every cluster ID is in
+// the range [0, <number of clusters>) and returns the number of clusters.
+size_t CompactClustering(Clustering* clustering);
+
+// Determines what type of unclustered vertex the input vertex is.
+//
+// Arguments:
+//   clustering
+//     A clustering of the graph `graph`.
+//  vertex
+//    The vertex of interest.
+//  vertex_id
+//     Vertex ID of the vertex of interest. `clustering[vertex_id]` should be
+//     `kUnclustered`.
+template <class Vertex>
+UnclusteredType DetermineUnclusteredType(
+    const Clustering& clustering, Vertex vertex, uintE vertex_id) {
+  bool is_hub{false};
+  // `candidate_cluster` holds a cluster ID that vertex i is adjacent to, or
+  // `kUnclustered` before such a cluster is found.
+  uintE candidate_cluster{kUnclustered};
+  const auto check_neighbor{[&](
+      const uintE v_id, const uintE neighbor_id, pbbslib::empty) {
+    const uintE neighbor_cluster{clustering[neighbor_id]};
+    // If `candidate_cluster` is at its default value of `kUnclustered`, assign
+    // `neighbor_cluster` to it. Otherwise, if it has a value differing from
+    // `neighbor_cluster`, then we know vertex i is adjacent to multiple
+    // clusters and is a hub.
+    if (neighbor_cluster != kUnclustered &&
+        !(candidate_cluster == UINT_E_MAX &&
+          pbbs::atomic_compare_and_swap(
+                  &candidate_cluster, UINT_E_MAX, neighbor_cluster)) &&
+        candidate_cluster != neighbor_cluster && !is_hub) {
+      is_hub = true;
+    }
+  }};
+  vertex.mapOutNgh(vertex_id, check_neighbor);
+  return is_hub ? UnclusteredType::kHub : UnclusteredType::kOutlier;
+}
+
+}  // namespace scan


### PR DESCRIPTION
- move some SCAN-related functions not specific to `IndexBased` implementation into a separate `utils.h` file --- if for some reason I write more SCAN implementations, then it's easy to move the `utils.h` file out to the parent `SCAN/` directory to be shared
- add a function for computing the modularity of a clustering to `utils.h`