### PR TITLE
bazelrc: Fix visibility warnings when compiling Python bindings on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -28,6 +28,7 @@ build --cxxopt=-DUSEMALLOC
 build --cxxopt=-pthread      # necessary for homegrown scheduler
 build --cxxopt=-march=native
 build --cxxopt=-fvisibility=hidden
+build --cxxopt=-fvisibility-inlines-hidden
 build -c opt
 
 # C++ warning flags.

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,7 @@ build --cxxopt=-DAMORTIZEDPD # use amortized_bytepd encoding scheme for compress
 build --cxxopt=-DUSEMALLOC
 build --cxxopt=-pthread      # necessary for homegrown scheduler
 build --cxxopt=-march=native
+build --cxxopt=-fvisibility=hidden
 build -c opt
 
 # C++ warning flags.

--- a/benchmarks/BFS/NonDeterministicBFS/unit_tests/BUILD
+++ b/benchmarks/BFS/NonDeterministicBFS/unit_tests/BUILD
@@ -1,4 +1,6 @@
-cc_test(
+load("//internal_tools:build_defs.bzl", "gbbs_cc_test")
+
+gbbs_cc_test(
     name = "test_bfs",
     srcs = ["test_bfs.cc"],
     deps = [

--- a/benchmarks/SCAN/IndexBased/unit_tests/BUILD
+++ b/benchmarks/SCAN/IndexBased/unit_tests/BUILD
@@ -1,4 +1,6 @@
-cc_test(
+load("//internal_tools:build_defs.bzl", "gbbs_cc_test")
+
+gbbs_cc_test(
     name = "scan_test",
     srcs = ["scan_test.cc"],
     deps = [
@@ -12,7 +14,7 @@ cc_test(
     ],
 )
 
-cc_test(
+gbbs_cc_test(
     name = "utils_test",
     srcs = ["utils_test.cc"],
     deps = [

--- a/benchmarks/SCAN/Naive/unit_tests/BUILD
+++ b/benchmarks/SCAN/Naive/unit_tests/BUILD
@@ -1,4 +1,6 @@
-cc_test(
+load("//internal_tools:build_defs.bzl", "gbbs_cc_test")
+
+gbbs_cc_test(
     name = "scan_test",
     srcs = ["scan_test.cc"],
     deps = [

--- a/internal_tools/build_defs.bzl
+++ b/internal_tools/build_defs.bzl
@@ -1,0 +1,24 @@
+"""Custom Bazel build rules."""
+
+
+def gbbs_cc_test(
+    name, copts=[], features=[], tags=[], deps=[], linkstatic=True, **kwargs
+):
+    """Builds a C++ test. Analogous to the default `cc_test` Bazel rule."""
+    # We set `linkstatic` to `True` by default (versus `cc_test` which sets it to
+    # `False` by default). Rationale: the `-fvisibility=hidden` GCC flag makes
+    # symbols private by default in shared libraries. With `linkstatic = False`,
+    # then, unit tests will fail to compile when their tests involve non-public
+    # symbols, which is most of the time. (In contrast, some symbols are public,
+    # e.g., Python bindings that we purposely expose --- it would make sense to
+    # set `linkstatic = False` for unit tests on these symbols.)
+
+    native.cc_test(
+        name=name,
+        copts=copts,
+        features=features,
+        tags=tags,
+        deps=deps,
+        linkstatic=linkstatic,
+        **kwargs
+    )

--- a/ligra/unit_tests/BUILD
+++ b/ligra/unit_tests/BUILD
@@ -1,4 +1,6 @@
-cc_test(
+load("//internal_tools:build_defs.bzl", "gbbs_cc_test")
+
+gbbs_cc_test(
     name = "graph_io_test",
     srcs = ["graph_io_test.cc"],
     deps = [
@@ -8,7 +10,7 @@ cc_test(
     ],
 )
 
-cc_test(
+gbbs_cc_test(
     name = "graph_test",
     srcs = ["graph_test.cc"],
     deps = [
@@ -18,7 +20,7 @@ cc_test(
     ],
 )
 
-cc_test(
+gbbs_cc_test(
     name = "undirected_edge_test",
     srcs = ["undirected_edge_test.cc"],
     deps = [

--- a/pbbslib/unit_tests/BUILD
+++ b/pbbslib/unit_tests/BUILD
@@ -1,4 +1,6 @@
-cc_test(
+load("//internal_tools:build_defs.bzl", "gbbs_cc_test")
+
+gbbs_cc_test(
     name = "seq_test",
     srcs = ["seq_test.cc"],
     deps = [


### PR DESCRIPTION
## why

fixes linker warnings that occur from `bazel build -c fastbuild //pybindings:gbbs_lib.so` on macOS:
```
ld: warning: direct access in function 'unsigned long std::__1::__str_rfind<char, unsigned long, std::__1::char_traits<char>, 18446744073709551615ul>(char const*, unsigned long, char const*, unsigned long, unsigned long)' from file 'bazel-out/darwin-fastbuild/bin/pybindings/_objs/gbbs_lib.so/gbbs_lib.o' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'bazel-out/darwin-fastbuild/bin/ligra/libgraph_io.a(graph_io_57e27e1f35413a2143192c0c15671883.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings
```

## how

The linker error appears because pybind bindings are compiled using the `-fvisibility=hidden` compiler flag, but our other libraries are not. To remedy this, we add the `-fvisibility=hidden` flag to everything. This marks symbols as hidden in shared libraries by default and is supposed to come with [other benefits](https://gcc.gnu.org/wiki/Visibility), though I haven't run any benchmarks to check whether check whether GBBS gets any performance benefit.

This breaks unit tests because now the unit tests can't see the symbols for the functions they're testing. The fix is to link unit tests statically with the `linkstatic` Bazel flag. I wrote a new Bazel macro in `internal_tools/build_defs.bzl` to add this Bazel flag everywhere.