### PR TITLE
graph: Fix some compilation errors for macOS Clang

### DIFF
--- a/gbbs/graph.h
+++ b/gbbs/graph.h
@@ -148,7 +148,7 @@ struct symmetric_graph {
         << "TODO: map edgeMapReduce interface to the one in edge_map_reduce.h"
         << std::endl;
     exit(-1);
-    return vertexSubset(n);
+    return vertexSubsetData<Data>(n);
   }
 
   template <class VS, class Map, class Reduce>
@@ -158,7 +158,7 @@ struct symmetric_graph {
         << "TODO: map edgeMapReduce interface to the one in edge_map_reduce.h"
         << std::endl;
     exit(-1);
-    return vertexSubset(n);
+    return vertexSubsetData<uintE>(n);
   }
 
   // =================== VertexSubset Operators: Packing =====================
@@ -195,7 +195,9 @@ struct symmetric_graph {
     assert(newN == G.num_vertices());
     return symmetric_graph<symmetric_vertex, W>(
         newVData, newN, newM,
-        [=]() { pbbslib::free_arrays(newVData, newEdges); }, newEdges);
+        [newVData = newVData, newEdges = newEdges]() {
+          pbbslib::free_arrays(newVData, newEdges);
+        }, newEdges);
   }
 
   template <
@@ -209,7 +211,9 @@ struct symmetric_graph {
     assert(newN == G.num_vertices());
     return symmetric_graph<csv_byte, W>(
         newVData, newN, newM,
-        [=]() { pbbslib::free_arrays(newVData, newEdges); }, newEdges);
+        [newVData = newVData, newEdges = newEdges]() {
+          pbbslib::free_arrays(newVData, newEdges);
+        }, newEdges);
   }
 
   // Used by MST and MaximalMatching


### PR DESCRIPTION
- in `nghReduce()`, use the correct return type
- in lambda functions, explicitly capture variables declared via structured binding (implicit capture doesn't work due to Apple Clang following a buggy, now outdated part of the C++ standard https://stackoverflow.com/q/46114214/4865149 )