### PR TITLE
SCAN/IndexBased: Add serialization for index

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,6 +19,14 @@ http_archive(
   sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
 )
 
+http_archive(
+  name = "cereal",
+  urls = ["https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz"],
+  strip_prefix = "cereal-1.3.0",
+  sha256 = "329ea3e3130b026c03a4acc50e168e7daff4e6e661bc6a7dfec0d77b570851d5",
+  build_file = "BUILD_cereal.bazel",
+)
+
 # pybind bazel bindings
 PYBIND11_BAZEL_COMMIT = "656fd69e83e80ccef8a3e3935d1ff4f604332e81"
 http_archive(

--- a/benchmarks/SCAN/IndexBased/BUILD
+++ b/benchmarks/SCAN/IndexBased/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "//pbbslib:sample_sort",
         "//pbbslib:seq",
         "//pbbslib:utilities",
+        "@cereal",
     ],
 )
 

--- a/benchmarks/SCAN/IndexBased/scan.cc
+++ b/benchmarks/SCAN/IndexBased/scan.cc
@@ -119,6 +119,8 @@ void AttachNoncoresToClusters(
 
 }  // namespace
 
+Index::Index() : num_vertices_{0}, neighbor_order_{}, core_order_{} {}
+
 Clustering Index::Cluster(const uint64_t mu, const float epsilon) const {
   const pbbs::sequence<uintE> cores{core_order_.GetCores(mu, epsilon)};
   if (cores.empty()) {
@@ -146,6 +148,14 @@ Clustering Index::Cluster(const uint64_t mu, const float epsilon) const {
   AttachNoncoresToClusters(
       neighbor_order_, cores, core_similar_edge_counts, &clustering);
   return clustering;
+}
+
+bool operator==(const Index& index_1, const Index& index_2) {
+  return
+    std::tie(
+        index_1.num_vertices_, index_1.neighbor_order_, index_1.core_order_)
+    == std::tie(
+        index_2.num_vertices_, index_2.neighbor_order_, index_2.core_order_);
 }
 
 }  // namespace indexed_scan

--- a/benchmarks/SCAN/IndexBased/scan_helpers.cc
+++ b/benchmarks/SCAN/IndexBased/scan_helpers.cc
@@ -17,9 +17,8 @@ struct VertexDegree {
 namespace internal {
 
 bool operator==(const EdgeSimilarity& a, const EdgeSimilarity& b) {
-  constexpr float kEpsilon{1e-6};
-  return std::tie(a.source, a.neighbor) == std::tie(b.source, b.neighbor) &&
-    std::abs(a.similarity - b.similarity) < kEpsilon;
+  return std::tie(a.source, a.neighbor, a.similarity)
+    == std::tie(b.source, b.neighbor, b.similarity);
 }
 
 std::ostream&
@@ -30,9 +29,8 @@ operator<<(std::ostream& os, const EdgeSimilarity& edge_similarity) {
 }
 
 bool operator==(const CoreThreshold& a, const CoreThreshold& b) {
-  constexpr float kEpsilon{1e-6};
-  return a.vertex_id == b.vertex_id &&
-    std::abs(a.threshold - b.threshold) < kEpsilon;
+  return std::tie(a.vertex_id, a.threshold)
+    == std::tie(b.vertex_id, b.threshold);
 }
 
 std::ostream&

--- a/benchmarks/SCAN/IndexBased/scan_helpers.cc
+++ b/benchmarks/SCAN/IndexBased/scan_helpers.cc
@@ -48,6 +48,8 @@ void ReportTime([[maybe_unused]] const timer& t) {
 #endif
 }
 
+NeighborOrder::NeighborOrder() : similarities_{}, similarities_by_source_{} {}
+
 const pbbs::range<EdgeSimilarity*>&
 NeighborOrder::operator[](size_t source) const {
   return similarities_by_source_[source];
@@ -67,6 +69,13 @@ pbbs::range<EdgeSimilarity*>* NeighborOrder::begin() const {
 
 pbbs::range<EdgeSimilarity*>* NeighborOrder::end() const {
   return similarities_by_source_.end();
+}
+
+bool operator==(const NeighborOrder& order_1, const NeighborOrder& order_2) {
+  // In well-formed neighbor orders, `similarities_by_source_` is fully
+  // determined by `similarities_`. Therefore, the equality operator does not
+  // need to check `similarities_by_source`.
+  return order_1.similarities_ == order_2.similarities_;
 }
 
 pbbs::sequence<pbbs::sequence<CoreThreshold>> ComputeCoreOrder(
@@ -145,6 +154,8 @@ pbbs::sequence<pbbs::sequence<CoreThreshold>> ComputeCoreOrder(
   return core_order;
 }
 
+CoreOrder::CoreOrder() : num_vertices_{0} , order_{} {}
+
 CoreOrder::CoreOrder(const NeighborOrder& neighbor_order)
     : num_vertices_{neighbor_order.size()}
     , order_{ComputeCoreOrder(neighbor_order)} {}
@@ -171,6 +182,11 @@ CoreOrder::GetCores(const uint64_t mu, const float epsilon) const {
       [](const internal::CoreThreshold& core_threshold) {
         return core_threshold.vertex_id;
       });
+}
+
+bool operator==(const CoreOrder& order_1, const CoreOrder& order_2) {
+  return std::tie(order_1.num_vertices_, order_1.order_)
+    == std::tie(order_2.num_vertices_, order_2.order_);
 }
 
 }  // namespace internal

--- a/benchmarks/SCAN/IndexBased/scan_helpers.h
+++ b/benchmarks/SCAN/IndexBased/scan_helpers.h
@@ -391,7 +391,7 @@ template<class CerealArchive>
 void CoreOrder::load(CerealArchive& archive) {
   size_t max_mu;
   archive(num_vertices_, max_mu);
-  order_ = sequence<pbbs::sequence<CoreThreshold>>::no_init(max_mu);
+  order_ = sequence<pbbs::sequence<CoreThreshold>>{max_mu};
   for (auto& cores : order_) {
     size_t num_cores;
     archive(num_cores);

--- a/benchmarks/SCAN/IndexBased/scan_helpers.h
+++ b/benchmarks/SCAN/IndexBased/scan_helpers.h
@@ -391,7 +391,7 @@ template<class CerealArchive>
 void CoreOrder::load(CerealArchive& archive) {
   size_t max_mu;
   archive(num_vertices_, max_mu);
-  order_ = sequence<pbbs::sequence<CoreThreshold>>{max_mu};
+  order_ = sequence<pbbs::sequence<CoreThreshold>>(max_mu);
   for (auto& cores : order_) {
     size_t num_cores;
     archive(num_cores);

--- a/benchmarks/SCAN/IndexBased/scan_helpers.h
+++ b/benchmarks/SCAN/IndexBased/scan_helpers.h
@@ -377,8 +377,7 @@ void NeighborOrder::load(CerealArchive& archive) {
 
 template<class CerealArchive>
 void CoreOrder::save(CerealArchive& archive) const {
-  archive(num_vertices_);
-  archive(order_.size());
+  archive(num_vertices_, order_.size());
   for (const auto& cores : order_) {
     archive(cores.size());
     for (const auto& core : cores) {

--- a/benchmarks/SCAN/IndexBased/scan_helpers.h
+++ b/benchmarks/SCAN/IndexBased/scan_helpers.h
@@ -31,9 +31,6 @@ struct EdgeSimilarity {
   // Similarity of source vertex to neighbor vertex.
   float similarity;
 };
-// Beware that this equality operator compares the floating-point field
-// approximately. This is convenient for unit tests but might not be appropriate
-// for other uses (e.g., this operator is not transitive).
 bool operator==(const EdgeSimilarity&, const EdgeSimilarity&);
 std::ostream& operator<<(std::ostream& os, const EdgeSimilarity&);
 
@@ -102,9 +99,6 @@ struct CoreThreshold {
     archive(vertex_id, threshold);
   }
 };
-// Beware that this equality operator compares the floating-point field
-// approximately. This is convenient for unit tests but might not be appropriate
-// for other uses (e.g., this operator is not transitive)
 bool operator==(const CoreThreshold&, const CoreThreshold&);
 std::ostream& operator<<(std::ostream& os, const CoreThreshold&);
 

--- a/benchmarks/SCAN/IndexBased/unit_tests/BUILD
+++ b/benchmarks/SCAN/IndexBased/unit_tests/BUILD
@@ -10,6 +10,7 @@ gbbs_cc_test(
         "//gbbs:undirected_edge",
         "//gbbs:vertex",
         "//pbbslib:seq",
+        "@cereal",
         "@googletest//:gtest_main",
     ],
 )

--- a/benchmarks/SCAN/IndexBased/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/IndexBased/unit_tests/scan_test.cc
@@ -579,4 +579,11 @@ TEST(Serialization, BasicUsage) {
     archive(deserialized_index);
   }
   EXPECT_EQ(index, deserialized_index);
+  {
+    constexpr uint64_t kMu{2};
+    constexpr float kEpsilon{0.73};
+    const i::Clustering clustering_1{index.Cluster(kMu, kEpsilon)};
+    const i::Clustering clustering_2{deserialized_index.Cluster(kMu, kEpsilon)};
+    EXPECT_EQ(clustering_1, clustering_2);
+  }
 }

--- a/benchmarks/SCAN/IndexBased/unit_tests/scan_test.cc
+++ b/benchmarks/SCAN/IndexBased/unit_tests/scan_test.cc
@@ -550,6 +550,7 @@ TEST(Cluster, TwoClusterGraph) {
 }
 
 TEST(Serialization, BasicUsage) {
+  // Check that serialization and deserialization of the index works.
   // Graph diagram:
   //     0 --- 1 -- 2 -- 5
   //           |   /|
@@ -579,11 +580,12 @@ TEST(Serialization, BasicUsage) {
     archive(deserialized_index);
   }
   EXPECT_EQ(index, deserialized_index);
-  {
-    constexpr uint64_t kMu{2};
-    constexpr float kEpsilon{0.73};
-    const i::Clustering clustering_1{index.Cluster(kMu, kEpsilon)};
-    const i::Clustering clustering_2{deserialized_index.Cluster(kMu, kEpsilon)};
-    EXPECT_EQ(clustering_1, clustering_2);
-  }
+
+  // Check that the deserialized index doesn't seg-fault or do anything weird
+  // when used.
+  constexpr uint64_t kMu{2};
+  constexpr float kEpsilon{0.73};
+  const i::Clustering clustering_1{index.Cluster(kMu, kEpsilon)};
+  const i::Clustering clustering_2{deserialized_index.Cluster(kMu, kEpsilon)};
+  EXPECT_EQ(clustering_1, clustering_2);
 }

--- a/external/BUILD_cereal.bazel
+++ b/external/BUILD_cereal.bazel
@@ -1,0 +1,6 @@
+cc_library(
+    name = "cereal",
+    hdrs = glob(["include/cereal/**/*.hpp"]),
+    strip_include_prefix = "include/",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
why: shouldn't have to read in the graph and recompute index every time -- why not serialize the index itself and read that in instead of reading the graph?
how: uses [cereal](http://uscilab.github.io/cereal/) library