### PR TITLE
Making GBBS compile with OpenMP.

### DIFF
--- a/gbbs/bridge.h
+++ b/gbbs/bridge.h
@@ -70,8 +70,8 @@ inline void parallel_for_alloc(Af init_alloc, Df finish_alloc, long start,
   {
     alloc = new A();
     init_alloc(alloc);
-    parallel_for_1(start, end, [&](size_t i) { f(i, alloc); }, granularity,
-                   conservative);
+    parallel_for(start, end, [&](size_t i) { f(i, alloc); }, granularity,
+                 conservative);
     //#pragma omp for schedule(dynamic, 1) nowait
     // for(long i=start; i<end; i++) f(i, alloc);
     finish_alloc(alloc);


### PR DESCRIPTION
Before this change, the command `bazel build --config=openmp //...` produced the following compilation error (with g++ (GCC) 12.1.0 on CentOS Linux release 7.9.2009):

```
benchmarks/CycleCounting/Parallel5Cycle/FiveCycle.cc:102:1:   required from here
./gbbs/bridge.h:73:19: error: 'parallel_for_1' was not declared in this scope
   73 |     parallel_for_1(start, end, [&](size_t i) { f(i, alloc); }, granularity,
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   74 |                    conservative);
      |                    ~~~~~~~~~~~~~
```

With this change, `bazel build --config=openmp //...` completed successfully. Then, I was able to run the BFS benchmark as follows:

```
$ bazel run --config=openmp //benchmarks/BFS/NonDeterministicBFS:BFS_main -- -s -src 10 -rounds 1 $PWD/inputs/rMatGraph_J_5_100 INFO: Using Bazel Remote listening on 127.0.0.1:39382 INFO: Running Bazel version 6.0.0
INFO: Invocation ID: 24ed1df9-86c0-4681-a433-f5378b838dc0 INFO: Analyzed target //benchmarks/BFS/NonDeterministicBFS:BFS_main (0 packages loaded, 0 targets configured). INFO: Found 1 target...
Target //benchmarks/BFS/NonDeterministicBFS:BFS_main up-to-date:
  bazel-bin/benchmarks/BFS/NonDeterministicBFS/BFS_main
INFO: Elapsed time: 0.102s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action INFO: Running command line: bazel-bin/benchmarks/BFS/NonDeterministicBFS/BFS_main -s -src 10 -rounds 1 /home/MY_USER_NAME/src-repos/gbbs/inputs/rMatGraph_J_5_100 1
1
2
16
52
42
11
Reachable: 125
```