### PR TITLE
Fix infinite loop in ApproximateSetCover at bucket 0 due to unsigned underflow

### DIFF
--- a/benchmarks/ApproximateSetCover/MANISBPT11/ApproximateSetCover.h
+++ b/benchmarks/ApproximateSetCover/MANISBPT11/ApproximateSetCover.h
@@ -139,7 +139,8 @@ inline parlay::sequence<uintE> SetCover(Graph& G, size_t num_buckets = 512) {
 
     // 3. sets -> elements (count and add to cover if enough elms were won)
     const size_t low_threshold =
-        std::max((size_t)ceil(pow(1.0 + sc::epsilon, cur_bkt - 1)), (size_t)1);
+        (cur_bkt == 0) ? (size_t)1
+                       : std::max((size_t)ceil(pow(1.0 + sc::epsilon, cur_bkt - 1)), (size_t)1);
     auto won_ngh_f = [&](const uintE& u, const uintE& v, const W& wgh) -> bool {
       return Elms[v] == perm[u];
     };


### PR DESCRIPTION
`cur_bkt` is `size_t`, so when `cur_bkt == 0`, `cur_bkt - 1` wraps to `SIZE_MAX`. This makes `pow(1.0 + epsilon, SIZE_MAX)` evaluate to infinity, and `size_t`(infinity) is UB that yields a huge low_threshold. No vertex can satisfy `numWon >= low_threshold`, causing an infinite loop at bucket 0 for any graph with `degree-1` vertices.



----------------------------------------ORIGINAL-----------------------------------------
```
    const size_t low_threshold =
        std::max((size_t)ceil(pow(1.0 + sc::epsilon, cur_bkt - 1)), (size_t)1);
```
------------------------------------------FIXED--------------------------------------------
```
    const size_t low_threshold =
        (cur_bkt == 0) ? (size_t)1
                       : std::max((size_t)ceil(pow(1.0 + sc::epsilon, cur_bkt - 1)), (size_t)1);
```